### PR TITLE
Update Intl WG README to reflect decharter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# Intl Working Group
+# (dechartered) `Intl` Working Group
 
 ![Intl logo](img/Intl.png)
+
+# This WG has been [dechartered](https://github.com/nodejs/TSC/issues/353) —
+# Please see [nodejs/i18n](https://github.com/nodejs/i18n) for current activity
+
+ _(content kept for archival purposes)_
+
+-----
 
 ## Mandate
 


### PR DESCRIPTION
In light of https://github.com/nodejs/TSC/issues/353 and the new https://github.com/nodejs/i18n WG,  change the landing page of the Intl WG to reflect its status. FYI @obensource and https://github.com/nodejs/community-committee/issues/114

-----

(FYI current WG members, please consider joining https://github.com/nodejs/i18n if desired: 
  + Caridy Patiño (@caridy)
  + Daijirō Wachi (@watilde)
  + James Snell (@jasnell)
  + Kevin Jose Martin (@KevinMartin)
  + Michael Dawson (@mhdawson) 
  + Rafael Xavier de Souza (@rxaviers) 
  + Rick Waldron (@rwaldron)
  + Steven Atkin (@stevenatkin)
)